### PR TITLE
Fix: Removing google news 

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -11,7 +11,6 @@
 	{{/* NOTE: These Hugo Internal Templates can be found starting at
 	https://github.com/gohugoio/hugo/tree/master/tpl/tplimpl/embedded/templates */}}
 	{{- template "_internal/opengraph.html" . -}}
-	{{- template "_internal/google_news.html" . -}}
 	{{- template "_internal/schema.html" . -}}
 	{{- template "_internal/twitter_cards.html" . -}}
 	{{ template "_internal/google_analytics_async.html" . }}


### PR DESCRIPTION
**Removed deprecated `google_news.html` file from  head.html file.**

**Related Issue**
closes #32 

**Files Changed:** `head.html`

**Console Logs**

![image](https://github.com/GDGToulouse/devfest-theme-hugo/assets/124715224/d00c948f-fc66-4935-bb78-961622b26a3f)
