### PR TITLE
Fixing google_analytics template

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -13,7 +13,7 @@
 	{{- template "_internal/opengraph.html" . -}}
 	{{- template "_internal/schema.html" . -}}
 	{{- template "_internal/twitter_cards.html" . -}}
-	{{ template "_internal/google_analytics_async.html" . }}
+	{{ template "_internal/google_analytics.html" . }}
 	{{ end }}
 
 	{{ hugo.Generator }}


### PR DESCRIPTION
Fixing google_analytics_async template by changing its name to google_analytics 

Ref: https://github.com/gohugoio/hugo/commit/ebfca61ac4d4b62b3e4a50477826a85c06b44552  